### PR TITLE
harden linux installer package selection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,5 +25,10 @@ jobs:
       - name: Setup just
         uses: extractions/setup-just@v3
 
+      - name: Check installer
+        run: |
+          bash -n scripts/install.sh scripts/install_test.sh
+          bash scripts/install_test.sh
+
       - name: Compile
         run: just compile

--- a/README.md
+++ b/README.md
@@ -42,9 +42,12 @@ curl -fsSL https://pln.sh/install.sh | bash
 ```
 
 A thin wrapper around your platform's package manager (Homebrew on
-macOS, apt or yum on Linux), so upgrades, uninstalls, and service files
-are managed natively. On macOS, see the [FAQ](#faq) for a first-connect
-permissions note.
+macOS, apt/dnf/yum/zypper on Linux), so upgrades, uninstalls, and
+service files are managed natively. On Linux, the installer reads
+`/etc/os-release` and refuses to guess on unknown distros; pass
+`--method tarball` to opt in to a `/usr/local/bin` binary install with
+the same daemon provisioning. On macOS, see the [FAQ](#faq) for a
+first-connect permissions note.
 
 ### Two commands to a cluster
 

--- a/cmd/pln/daemon_test.go
+++ b/cmd/pln/daemon_test.go
@@ -60,3 +60,24 @@ func TestUserPlnPlistPath(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, strings.HasSuffix(got, "/Library/LaunchAgents/sh.pln.home.plist"), "got %q", got)
 }
+
+func TestRenderSystemdUnit_UsesPackageBinary(t *testing.T) {
+	got, err := renderSystemdUnit("/usr/bin/pln")
+	require.NoError(t, err)
+	require.Contains(t, string(got), "ExecStart=/usr/bin/pln --dir /var/lib/pln up")
+	require.NotContains(t, string(got), systemdBinaryPlaceholder)
+}
+
+func TestRenderSystemdUnit_UsesTarballBinary(t *testing.T) {
+	got, err := renderSystemdUnit("/usr/local/bin/pln")
+	require.NoError(t, err)
+	require.Contains(t, string(got), "ExecStart=/usr/local/bin/pln --dir /var/lib/pln up")
+	require.NotContains(t, string(got), systemdBinaryPlaceholder)
+}
+
+func TestSupportedSystemdPlnBinary(t *testing.T) {
+	require.True(t, supportedSystemdPlnBinary("/usr/bin/pln"))
+	require.True(t, supportedSystemdPlnBinary("/usr/local/bin/pln"))
+	require.False(t, supportedSystemdPlnBinary("/tmp/pln"))
+	require.False(t, supportedSystemdPlnBinary("/home/alice/bin/pln"))
+}

--- a/cmd/pln/pln.service
+++ b/cmd/pln/pln.service
@@ -8,7 +8,7 @@ Wants=network-online.target
 Type=simple
 User=pln
 Group=pln
-ExecStart=/usr/bin/pln --dir /var/lib/pln up
+ExecStart={{PLN_BINARY}} --dir /var/lib/pln up
 Restart=on-failure
 RestartSec=5
 

--- a/cmd/pln/service.go
+++ b/cmd/pln/service.go
@@ -11,6 +11,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
+	"syscall"
 
 	"github.com/spf13/cobra"
 
@@ -18,8 +20,9 @@ import (
 )
 
 const (
-	plnUnitDir  = "/lib/systemd/system"
-	plnUnitName = "pln.service"
+	plnUnitDir               = "/lib/systemd/system"
+	plnUnitName              = "pln.service"
+	systemdBinaryPlaceholder = "{{PLN_BINARY}}"
 )
 
 //go:embed pln.service
@@ -69,11 +72,19 @@ func runDaemonInstall(cmd *cobra.Command, _ []string) error {
 	if err := plnfs.Provision(plnfs.SystemDir); err != nil {
 		return fmt.Errorf("provision: %w", err)
 	}
+	plnBinary, err := systemdPlnBinaryPath()
+	if err != nil {
+		return err
+	}
+	unit, err := renderSystemdUnit(plnBinary)
+	if err != nil {
+		return err
+	}
 
 	if err := os.MkdirAll(plnUnitDir, 0o755); err != nil { //nolint:mnd
 		return fmt.Errorf("create %s: %w", plnUnitDir, err)
 	}
-	if err := os.WriteFile(filepath.Join(plnUnitDir, plnUnitName), systemdUnit, 0o644); err != nil { //nolint:mnd,gosec
+	if err := os.WriteFile(filepath.Join(plnUnitDir, plnUnitName), unit, 0o644); err != nil { //nolint:mnd,gosec
 		return fmt.Errorf("write unit: %w", err)
 	}
 
@@ -91,7 +102,69 @@ func runDaemonInstall(cmd *cobra.Command, _ []string) error {
 			fmt.Fprintf(cmd.OutOrStdout(), "added %s to the pln group -- log out and back in for CLI access without sudo\n", sudoUser)
 		}
 	}
-	fmt.Fprintln(cmd.OutOrStdout(), "pln daemon installed at "+plnUnitDir+"/"+plnUnitName)
+	fmt.Fprintf(cmd.OutOrStdout(), "pln daemon installed at %s/%s using %s\n", plnUnitDir, plnUnitName, plnBinary)
+	return nil
+}
+
+func renderSystemdUnit(plnBinary string) ([]byte, error) {
+	unit := string(systemdUnit)
+	if !strings.Contains(unit, systemdBinaryPlaceholder) {
+		return nil, errors.New("systemd unit template is missing pln binary placeholder")
+	}
+	return []byte(strings.ReplaceAll(unit, systemdBinaryPlaceholder, plnBinary)), nil
+}
+
+func systemdPlnBinaryPath() (string, error) {
+	plnBinary, err := os.Executable()
+	if err != nil {
+		return "", fmt.Errorf("resolve pln binary path: %w", err)
+	}
+	plnBinary = filepath.Clean(plnBinary)
+	if !supportedSystemdPlnBinary(plnBinary) {
+		return "", fmt.Errorf("refusing to install systemd service for %s; install pln to /usr/bin/pln or /usr/local/bin/pln first", plnBinary)
+	}
+	if err := validateRootOwnedSystemdPath(plnBinary); err != nil {
+		return "", err
+	}
+	return plnBinary, nil
+}
+
+func supportedSystemdPlnBinary(plnBinary string) bool {
+	switch filepath.Clean(plnBinary) {
+	case "/usr/bin/pln", "/usr/local/bin/pln":
+		return true
+	default:
+		return false
+	}
+}
+
+func validateRootOwnedSystemdPath(path string) error {
+	for p := path; ; p = filepath.Dir(p) {
+		info, err := os.Lstat(p)
+		if err != nil {
+			return fmt.Errorf("inspect %s: %w", p, err)
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("refusing to install systemd service with symlinked path component %s", p)
+		}
+		if p == path {
+			if !info.Mode().IsRegular() {
+				return fmt.Errorf("refusing to install systemd service for non-regular binary %s", path)
+			}
+		} else if !info.IsDir() {
+			return fmt.Errorf("refusing to install systemd service with non-directory path component %s", p)
+		}
+		if info.Mode().Perm()&0o022 != 0 {
+			return fmt.Errorf("refusing to install systemd service with group/world-writable path component %s", p)
+		}
+		stat, ok := info.Sys().(*syscall.Stat_t)
+		if !ok || stat.Uid != 0 {
+			return fmt.Errorf("refusing to install systemd service with non-root-owned path component %s", p)
+		}
+		if p == string(filepath.Separator) {
+			break
+		}
+	}
 	return nil
 }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,11 +1,4 @@
 #!/usr/bin/env bash
-# Usage:
-#   curl -fsSL https://pln.sh/install.sh | bash
-#   curl -fsSL https://pln.sh/install.sh | bash -s -- --version v1.2.3
-#
-# The outer brace block ensures the whole script is parsed before any
-# command runs, so a truncated download fails to parse rather than
-# executing a partial installer.
 
 set -euo pipefail
 {
@@ -14,42 +7,71 @@ REPO="sambigeara/pollen"
 # Goreleaser rewrites this to the release tag; the untouched sentinel
 # triggers the API fallback below.
 VERSION="__VERSION__"
+# auto uses /etc/os-release to select a native package manager only when the
+# distro match is explicit. tarball is intentionally opt-in for unknown Linux.
+METHOD="auto"
+OS_RELEASE_FILE="${OS_RELEASE_FILE:-/etc/os-release}"
+OS=""
+ARCH=""
+INSTALL_TMPDIR=""
 
-log()   { printf '==> %s\n' "$*"; }
+log()   { printf '==> %s\n' "$*" >&2; }
 fatal() { printf 'error: %s\n' "$*" >&2; exit 1; }
 
 usage() {
     cat <<EOF
-Usage: install.sh [--version TAG]
+Usage: install.sh [--version TAG] [--method METHOD]
 
 Installs the pln binary. On Linux, also registers a systemd unit when
 systemd is present; the service is not started automatically. Run
 'sudo pln join <token>' after install to enrol this node.
+
+Options:
+  --version TAG     install a specific release (default: latest)
+  --method METHOD   Linux install method (auto|tarball; default: auto)
+
+auto reads /etc/os-release and only uses apt, dnf, yum, or zypper when the
+running distro confidently maps to that native package manager. Unknown Linux
+distros are refused instead of guessed; pass --method tarball to opt in to a
+/usr/local/bin binary install with daemon provisioning.
 EOF
 }
 
-while [ "$#" -gt 0 ]; do
-    case "$1" in
-        --version)
-            [ "$#" -ge 2 ] || fatal "--version requires a value"
-            VERSION="$2"
-            shift 2
-            ;;
-        -h|--help) usage; exit 0 ;;
-        *) fatal "unknown argument: $1 (try --help)" ;;
+parse_args() {
+    while [ "$#" -gt 0 ]; do
+        case "$1" in
+            --version)
+                [ "$#" -ge 2 ] || fatal "--version requires a value"
+                VERSION="$2"
+                shift 2
+                ;;
+            --method)
+                [ "$#" -ge 2 ] || fatal "--method requires a value"
+                METHOD="$2"
+                shift 2
+                ;;
+            -h|--help) usage; exit 0 ;;
+            *) fatal "unknown argument: $1 (try --help)" ;;
+        esac
+    done
+}
+
+validate_method() {
+    case "$METHOD" in
+        auto|tarball) ;;
+        *) fatal "unknown install method: $METHOD (expected auto|tarball)" ;;
     esac
-done
+}
 
-OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
-ARCH="$(uname -m)"
-case "$ARCH" in
-    x86_64)        ARCH="amd64" ;;
-    aarch64|arm64) ARCH="arm64" ;;
-    *)             fatal "unsupported architecture: $ARCH" ;;
-esac
-
-TMPDIR=$(mktemp -d)
-trap 'rm -rf "$TMPDIR"' EXIT
+detect_platform() {
+    OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
+    ARCH="$(uname -m)"
+    case "$ARCH" in
+        x86_64)        ARCH="amd64" ;;
+        aarch64|arm64) ARCH="arm64" ;;
+        *)             fatal "unsupported architecture: $ARCH" ;;
+    esac
+}
 
 need_sudo() {
     if [ "$(id -u)" -eq 0 ]; then
@@ -71,13 +93,70 @@ resolve_version() {
     [ -n "$VERSION" ] || fatal "could not determine latest version"
 }
 
+asset_name() {
+    local ext=$1
+    printf 'pln_%s_linux_%s.%s' "${VERSION#v}" "$ARCH" "$ext"
+}
+
 asset_url() {
     local ext=$1
-    printf 'https://github.com/%s/releases/download/%s/pln_%s_linux_%s.%s' \
-        "$REPO" "$VERSION" "${VERSION#v}" "$ARCH" "$ext"
+    printf 'https://github.com/%s/releases/download/%s/%s' \
+        "$REPO" "$VERSION" "$(asset_name "$ext")"
+}
+
+checksums_url() {
+    printf 'https://github.com/%s/releases/download/%s/checksums.txt' "$REPO" "$VERSION"
+}
+
+checksum_for_asset() {
+    local asset=$1
+    local checksums="$INSTALL_TMPDIR/checksums.txt"
+    local sum name
+
+    if [ ! -s "$checksums" ]; then
+        curl -fsSL "$(checksums_url)" -o "$checksums" || fatal "could not download release checksums"
+    fi
+
+    while read -r sum name; do
+        name=${name#./}
+        if [ "$name" = "$asset" ]; then
+            printf '%s' "$sum"
+            return 0
+        fi
+    done <"$checksums"
+
+    return 1
+}
+
+verify_checksum() {
+    local file=$1
+    local asset=$2
+    local expected actual
+
+    expected=$(checksum_for_asset "$asset") || fatal "checksum for $asset not found in release checksums"
+    if command -v sha256sum >/dev/null 2>&1; then
+        actual=$(sha256sum "$file")
+    elif command -v shasum >/dev/null 2>&1; then
+        actual=$(shasum -a 256 "$file")
+    else
+        fatal "sha256sum or shasum is required to verify downloads"
+    fi
+    actual=${actual%% *}
+
+    [ "$actual" = "$expected" ] || fatal "checksum mismatch for $asset"
+}
+
+download_asset() {
+    local ext=$1
+    local output=$2
+    local asset
+    asset=$(asset_name "$ext")
+    curl -fsSL "$(asset_url "$ext")" -o "$output"
+    verify_checksum "$output" "$asset"
 }
 
 install_macos() {
+    [ "$METHOD" = "auto" ] || fatal "--method is only supported on Linux"
     log "macOS detected; installing via Homebrew..."
     command -v brew >/dev/null 2>&1 || fatal "Homebrew is required. See https://brew.sh"
     brew install sambigeara/homebrew-pln/pln
@@ -86,12 +165,13 @@ install_macos() {
 
 install_deb() {
     log "Installing .deb via apt..."
-    local deb="$TMPDIR/pln.deb"
-    curl -fsSL "$(asset_url deb)" -o "$deb"
+    local deb
+    deb="$INSTALL_TMPDIR/$(asset_name deb)"
+    download_asset deb "$deb"
     # mktemp -d gives us a 0700 dir; apt's _apt user can't read it and
     # falls back to "unsandboxed as root" with a Permission denied notice
     # that looks like a failure. Open the path so the sandbox works.
-    chmod a+rx "$TMPDIR"
+    chmod a+rx "$INSTALL_TMPDIR"
     chmod a+r "$deb"
     $SUDO env NEEDRESTART_SUSPEND=1 DEBIAN_FRONTEND=noninteractive \
         apt-get install -y --allow-downgrades "$deb"
@@ -99,36 +179,136 @@ install_deb() {
 
 install_rpm() {
     local mgr=$1
+    local rpm
+    rpm="$INSTALL_TMPDIR/$(asset_name rpm)"
     log "Installing .rpm via $mgr..."
-    $SUDO "$mgr" install -y "$(asset_url rpm)"
+    download_asset rpm "$rpm"
+    case "$mgr" in
+        zypper)
+            # zypper aborts on unsigned packages even with --non-interactive;
+            # nfpms doesn't sign rpms today, so verify checksums first.
+            $SUDO "$mgr" --non-interactive install --allow-unsigned-rpm "$rpm"
+            ;;
+        *)
+            $SUDO "$mgr" install -y "$rpm"
+            ;;
+    esac
 }
 
 install_tarball() {
-    log "No supported package manager; installing from tarball..."
-    local tar="$TMPDIR/pln.tar.gz"
-    curl -fsSL "$(asset_url tar.gz)" -o "$tar"
-    $SUDO tar -xzf "$tar" -C /usr/local/bin pln
+    log "Installing from tarball..."
+    local tar extract_dir
+    tar="$INSTALL_TMPDIR/$(asset_name tar.gz)"
+    extract_dir="$INSTALL_TMPDIR/tarball"
+    mkdir "$extract_dir"
+    download_asset tar.gz "$tar"
+    tar -xzf "$tar" -C "$extract_dir" pln
+    if [ ! -f "$extract_dir/pln" ] || [ -L "$extract_dir/pln" ]; then
+        fatal "tarball did not contain a regular pln binary"
+    fi
+    $SUDO install -o root -g root -m 0755 "$extract_dir/pln" /usr/local/bin/pln
     $SUDO /usr/local/bin/pln daemon install
+}
+
+read_os_release_value() {
+    local key=$1
+    local line value
+
+    [ -r "$OS_RELEASE_FILE" ] || return 1
+    while IFS= read -r line; do
+        case "$line" in
+            "$key="*)
+                value=${line#*=}
+                case "$value" in
+                    \"*\") value=${value#\"}; value=${value%\"} ;;
+                    \'*\') value=${value#\'}; value=${value%\'} ;;
+                esac
+                printf '%s' "$value"
+                return 0
+                ;;
+        esac
+    done <"$OS_RELEASE_FILE"
+    return 1
+}
+
+missing_native_manager() {
+    local distro=$1
+    local expected=$2
+    fatal "detected $distro Linux but $expected is not installed; refusing to guess. Re-run with --method tarball to opt in to a /usr/local/bin binary install with daemon provisioning"
+}
+
+unsupported_linux() {
+    local id=$1
+    local id_like=$2
+    fatal "unsupported Linux distro (ID=${id:-unknown}, ID_LIKE=${id_like:-none}); refusing to guess a package manager. Re-run with --method tarball to opt in to a /usr/local/bin binary install with daemon provisioning"
+}
+
+# Map the running distro to its native package manager. We parse
+# /etc/os-release rather than source it or probe package-manager binaries:
+# foreign managers may be installed for cross-distro tooling without being
+# safe for this system (issue #4: dnf installed on openSUSE removed kernels).
+detect_method() {
+    local id id_like tokens
+    id=$(read_os_release_value ID || true)
+    id_like=$(read_os_release_value ID_LIKE || true)
+    [ -n "$id$id_like" ] || unsupported_linux "$id" "$id_like"
+
+    tokens=$(printf ' %s %s ' "$id" "$id_like" | tr '[:upper:]' '[:lower:]')
+    case "$tokens" in
+        *" debian "*|*" ubuntu "*|*" raspbian "*)
+            command -v apt-get >/dev/null 2>&1 && { printf 'apt'; return; }
+            missing_native_manager "Debian-like" "apt-get"
+            ;;
+        *" rhel "*|*" centos "*|*" rocky "*|*" almalinux "*|*" ol "*|*" amzn "*)
+            command -v yum >/dev/null 2>&1 && { printf 'yum'; return; }
+            command -v dnf >/dev/null 2>&1 && { printf 'dnf'; return; }
+            missing_native_manager "Fedora/RHEL-like" "dnf or yum"
+            ;;
+        *" fedora "*)
+            command -v dnf >/dev/null 2>&1 && { printf 'dnf'; return; }
+            command -v yum >/dev/null 2>&1 && { printf 'yum'; return; }
+            missing_native_manager "Fedora-like" "dnf or yum"
+            ;;
+        *" opensuse "*|*" opensuse-leap "*|*" opensuse-tumbleweed "*|*" suse "*|*" sles "*)
+            command -v zypper >/dev/null 2>&1 && { printf 'zypper'; return; }
+            missing_native_manager "SUSE-like" "zypper"
+            ;;
+    esac
+    unsupported_linux "$id" "$id_like"
+}
+
+resolve_linux_method() {
+    case "$METHOD" in
+        auto)    detect_method ;;
+        tarball) printf 'tarball' ;;
+        *)       fatal "unknown install method: $METHOD (expected auto|tarball)" ;;
+    esac
 }
 
 install_linux() {
     log "Linux detected."
+    local method
+    method=$(resolve_linux_method)
+    log "Install method: $method"
+
     need_sudo
     resolve_version
     log "Installing version $VERSION..."
+
     local upgrade=false
     if command -v pln >/dev/null 2>&1; then
         upgrade=true
     fi
-    if command -v apt-get >/dev/null 2>&1; then
-        install_deb
-    elif command -v dnf >/dev/null 2>&1; then
-        install_rpm dnf
-    elif command -v yum >/dev/null 2>&1; then
-        install_rpm yum
-    else
-        install_tarball
-    fi
+
+    case "$method" in
+        apt)     install_deb ;;
+        dnf)     install_rpm dnf ;;
+        yum)     install_rpm yum ;;
+        zypper)  install_rpm zypper ;;
+        tarball) install_tarball ;;
+        *)       fatal "internal error: resolved unknown install method: $method" ;;
+    esac
+
     if [ "$upgrade" = true ]; then
         log "Done."
     else
@@ -136,10 +316,23 @@ install_linux() {
     fi
 }
 
-case "$OS" in
-    darwin) install_macos ;;
-    linux)  install_linux ;;
-    *)      fatal "unsupported OS: $OS" ;;
-esac
+main() {
+    parse_args "$@"
+    validate_method
+    detect_platform
+
+    INSTALL_TMPDIR=$(mktemp -d)
+    trap 'rm -rf "$INSTALL_TMPDIR"' EXIT
+
+    case "$OS" in
+        darwin) install_macos ;;
+        linux)  install_linux ;;
+        *)      fatal "unsupported OS: $OS" ;;
+    esac
+}
+
+if [ -z "${BASH_SOURCE[0]}" ] || [ "${BASH_SOURCE[0]}" = "$0" ]; then
+    main "$@"
+fi
 
 }

--- a/scripts/install_test.sh
+++ b/scripts/install_test.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(CDPATH='' cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/install.sh"
+
+RUN_OUTPUT=""
+RUN_STATUS=0
+
+fail() {
+    printf 'not ok - %s\n' "$1" >&2
+    exit 1
+}
+
+make_fake_bins() {
+    local dir=$1
+    local name
+    shift
+    for name in "$@"; do
+        printf '#!/bin/sh\nexit 0\n' >"$dir/$name"
+        chmod +x "$dir/$name"
+    done
+}
+
+run_detect() {
+    local os_release=$1
+    local tmp bin tr_path
+    shift
+
+    tmp=$(mktemp -d)
+    bin="$tmp/bin"
+    mkdir "$bin"
+    printf '%s\n' "$os_release" >"$tmp/os-release"
+    tr_path=$(command -v tr)
+    ln -s "$tr_path" "$bin/tr"
+    make_fake_bins "$bin" "$@"
+
+    set +e
+    RUN_OUTPUT=$(OS_RELEASE_FILE="$tmp/os-release" PATH="$bin" detect_method 2>&1)
+    RUN_STATUS=$?
+    set -e
+
+    rm -rf "$tmp"
+}
+
+assert_detect() {
+    local name=$1
+    local want=$2
+    local os_release=$3
+    shift 3
+
+    run_detect "$os_release" "$@"
+    if [ "$RUN_STATUS" -ne 0 ]; then
+        fail "$name: expected $want, got failure: $RUN_OUTPUT"
+    fi
+    if [ "$RUN_OUTPUT" != "$want" ]; then
+        fail "$name: expected $want, got $RUN_OUTPUT"
+    fi
+}
+
+assert_refuses() {
+    local name=$1
+    local want=$2
+    local os_release=$3
+    shift 3
+
+    run_detect "$os_release" "$@"
+    if [ "$RUN_STATUS" -eq 0 ]; then
+        fail "$name: expected refusal, got $RUN_OUTPUT"
+    fi
+    case "$RUN_OUTPUT" in
+        *"$want"*) ;;
+        *) fail "$name: expected refusal containing '$want', got $RUN_OUTPUT" ;;
+    esac
+}
+
+assert_method() {
+    local name=$1
+    local method=$2
+    local want_status=$3
+    local want=$4
+
+    set +e
+    RUN_OUTPUT=$(METHOD="$method" resolve_linux_method 2>&1)
+    RUN_STATUS=$?
+    set -e
+
+    if [ "$RUN_STATUS" -ne "$want_status" ]; then
+        fail "$name: expected status $want_status, got $RUN_STATUS: $RUN_OUTPUT"
+    fi
+    case "$RUN_OUTPUT" in
+        *"$want"*) ;;
+        *) fail "$name: expected output containing '$want', got $RUN_OUTPUT" ;;
+    esac
+}
+
+assert_tarball_installs_root_owned_binary() {
+    local tmp src sudo_bin log
+
+    tmp=$(mktemp -d)
+    src="$tmp/src"
+    INSTALL_TMPDIR="$tmp/work"
+    FAKE_SUDO_LOG="$tmp/sudo.log"
+    export FAKE_SUDO_LOG
+    mkdir "$src" "$INSTALL_TMPDIR"
+    printf '#!/bin/sh\nexit 0\n' >"$src/pln"
+    chmod +x "$src/pln"
+
+    sudo_bin="$tmp/sudo"
+    printf '%s\n' '#!/bin/sh' "printf \"%s\\n\" \"\$*\" >> \"\$FAKE_SUDO_LOG\"" >"$sudo_bin"
+    chmod +x "$sudo_bin"
+    export SUDO="$sudo_bin"
+
+    download_asset() {
+        local output=$2
+        tar -czf "$output" -C "$src" pln
+    }
+
+    set +e
+    RUN_OUTPUT=$(install_tarball 2>&1)
+    RUN_STATUS=$?
+    set -e
+
+    if [ "$RUN_STATUS" -ne 0 ]; then
+        fail "tarball install: expected success, got failure: $RUN_OUTPUT"
+    fi
+
+    log=$(<"$FAKE_SUDO_LOG")
+    case "$log" in
+        *"install -o root -g root -m 0755 "*"/tarball/pln /usr/local/bin/pln"*) ;;
+        *) fail "tarball install: expected root-owned install command, got $log" ;;
+    esac
+    case "$log" in
+        *"/usr/local/bin/pln daemon install"*) ;;
+        *) fail "tarball install: expected daemon provisioning, got $log" ;;
+    esac
+    unset SUDO
+    rm -rf "$tmp"
+}
+
+assert_detect "debian uses apt" "apt" $'ID=debian' apt-get
+assert_detect "ubuntu-like uses apt" "apt" $'ID=linuxmint\nID_LIKE="ubuntu debian"' apt-get dnf
+assert_detect "fedora prefers dnf" "dnf" $'ID=fedora' dnf yum
+assert_detect "rhel can use yum" "yum" $'ID=rocky\nID_LIKE="rhel centos fedora"' yum
+assert_detect "rhel prefers yum over foreign dnf" "yum" $'ID=centos\nID_LIKE="rhel fedora"' dnf yum
+assert_detect "opensuse ignores foreign dnf" "zypper" $'ID=opensuse-tumbleweed\nID_LIKE="opensuse suse"' dnf zypper
+assert_refuses "unknown distro refuses" "unsupported Linux distro" $'ID=arch' dnf
+assert_refuses "debian without apt refuses" "apt-get is not installed" $'ID=debian' dnf
+assert_method "explicit tarball accepted" "tarball" 0 "tarball"
+assert_method "package-manager override refused" "dnf" 1 "unknown install method"
+assert_tarball_installs_root_owned_binary
+
+printf 'ok - install detection\n'

--- a/web/docs/index.html
+++ b/web/docs/index.html
@@ -376,7 +376,7 @@
 
             <h2 id="install">Install</h2>
             <pre><code>curl -fsSL https://pln.sh/install.sh | bash</code></pre>
-            <p>Wraps Homebrew on macOS and apt/yum on Linux. On macOS, state lives in <code>~/.pln</code>. On Linux, the installer runs <code>pln daemon install</code> to provision <code>/var/lib/pln</code> under a dedicated <code>pln</code> system user and adds the invoking user to the <code>pln</code> group for CLI access. Override either default with <code>$PLN_DIR</code>.</p>
+            <p>Wraps Homebrew on macOS and apt/dnf/yum/zypper on Linux. Linux package-manager selection is based on <code>/etc/os-release</code>; unknown distros are refused instead of guessed, and <code>--method tarball</code> opts in to a <code>/usr/local/bin</code> binary install with the same daemon provisioning. On macOS, state lives in <code>~/.pln</code>. On Linux, the installer runs <code>pln daemon install</code> to provision <code>/var/lib/pln</code> under a dedicated <code>pln</code> system user and adds the invoking user to the <code>pln</code> group for CLI access. Override either default with <code>$PLN_DIR</code>.</p>
 
             <h2 id="one-node-cluster">One-node cluster</h2>
             <pre><code>pln init


### PR DESCRIPTION
Select Linux package managers from /etc/os-release instead of probing installed tools, fail closed for unknown distros, verify release artifacts before install, and make tarball daemon provisioning render the systemd unit for /usr/local/bin/pln.

I'm not sure if it makes sense to lean on native package managers in the long term for linux installs--perhaps tarball-unpack and manual `pln.service` provisioning will be the cleaner approach. That said, I'm leaving it here for now (for backwards compat, and so I can think about it more).

REMINDER TO SELF: roll-out needs to be deliberate (run release job, then on success, immediately push install script to prod cluster).

Fixes https://github.com/Sambigeara/pollen/issues/4